### PR TITLE
The font color of links in dark mode now stay white.

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -1,3 +1,7 @@
 html.iframe body {
     background-color: transparent !important;
 }
+
+html.dark .list-group-item a {
+  color: #e1e1e1 !important;
+}


### PR DESCRIPTION
Links in dark mode will stay white like the rest of the text, matching what light mode does with black text.

Example of the home page with the changes:
<img width="1355" alt="Home Page Example" src="https://user-images.githubusercontent.com/38347315/209892495-fd15917e-a89c-4d5c-a256-5d32f017cd76.png">

Example of a detail page with the changes (note Gold is not a link, but the two items above it are): 
<img width="1371" alt="Tower Detail Example" src="https://user-images.githubusercontent.com/38347315/209892532-5998c431-163e-4dec-a1b2-caf282f119a2.png">
