### PR TITLE
Fix/mobile keyboard persistent nav

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,12 @@
 // @ts-check
+import React from "react"
 import Provider from "./src/utils/context"
+import { PersistentNav } from "./src/components/persistent-nav"
 
 /** @type {import('gatsby').GatsbyBrowser['wrapRootElement']} */
 export const wrapRootElement = Provider
+
+/** @type {import('gatsby').GatsbyBrowser['wrapPageElement']} */
+export const wrapPageElement = ({ element }) => {
+  return <PersistentNav>{element}</PersistentNav>
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,5 +1,7 @@
 // @ts-check
+import React from "react"
 import Provider from "./src/utils/context"
+import { PersistentNav } from "./src/components/persistent-nav"
 
 /** @type {import('gatsby').GatsbySSR['onPreRenderHTML']} */
 export const onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }) => {
@@ -46,3 +48,8 @@ export const onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }) =>
 
 /** @type {import('gatsby').GatsbySSR['wrapRootElement']} */
 export const wrapRootElement = Provider
+
+/** @type {import('gatsby').GatsbySSR['wrapPageElement']} */
+export const wrapPageElement = ({ element }) => {
+  return <PersistentNav>{element}</PersistentNav>
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,23 +1,11 @@
-import "bootstrap/dist/css/bootstrap.css"
-import "bootstrap-dark-5/dist/css/bootstrap-nightshade.css"
-import "react-bootstrap-typeahead/css/Typeahead.css"
-import "react-bootstrap-typeahead/css/Typeahead.bs5.css"
 import "./layout.css"
 
 import ClipboardJS from "clipboard"
-import { Link, navigate } from "gatsby"
-import React, { useContext, useEffect, useState } from "react"
+import React, { useContext, useEffect } from "react"
 import Container from "react-bootstrap/Container"
-import Navbar from "react-bootstrap/Navbar"
-import Toast from "react-bootstrap/Toast"
-import ToastContainer from "react-bootstrap/ToastContainer"
 import { Helmet } from "react-helmet"
 
-import { BsFillGearFill } from "@react-icons/all-files/bs/BsFillGearFill"
-import { FaHome } from "@react-icons/all-files/fa/FaHome"
-
 import { CopyButton } from "../components/clipboard"
-import { useDebounce } from "../hooks/debounce"
 import { GlobalContext } from "../utils/context"
 import { linkFor } from "../utils/links"
 
@@ -45,11 +33,6 @@ interface LayoutProps {
   headerFrom?: HeaderFromable
   headerRight?: React.ReactNode
   pageTitle?: string
-  query?: string | null | undefined
-  searchAutoFocus?: boolean | undefined
-  onSearch?: (query: string) => void
-  onSearchSubmit?: () => void
-  settingsBack?: boolean
   children: React.ReactNode
 }
 
@@ -61,31 +44,9 @@ const Layout = ({
   headerFrom,
   headerRight,
   pageTitle,
-  query,
-  searchAutoFocus,
-  onSearch,
-  onSearchSubmit,
-  settingsBack,
   children,
 }: LayoutProps) => {
   const ctx = useContext(GlobalContext)
-  const [searchFired, setSearchFired] = useState(false)
-  const navigateToSearch = useDebounce((query: string, setSearchFired: (arg0: boolean) => void) => {
-    console.debug("defaultOnSearch actually navigating", query)
-    // query = query.substring(0, query.length - 3)
-    void navigate(`/search/?q=${encodeURIComponent(query)}`, { state: { typing: true, query } })
-    setSearchFired(true)
-  }, 250)
-  if (!onSearch) {
-    onSearch = (query: string): void => {
-      console.debug("defaultOnSearch firing", query)
-      if (!searchFired) {
-        console.debug("defaultOnSearch navigating", query)
-        navigateToSearch(query, setSearchFired)
-      }
-      ctx.setQuery(query)
-    }
-  }
 
   useEffect(() => {
     const clipboard = new ClipboardJS(".clipboard")
@@ -99,85 +60,12 @@ const Layout = ({
     return () => clipboard.destroy()
   })
 
-  // Typescript otherwise complains that onSearch could be undefined even though it can't be.
-  const onSearchTypescriptSigh = onSearch
-
   return (
     <>
       <Helmet>
         <meta charSet="utf-8" />
         <title>{pageTitle || title || headerFrom?.name || "buddy.farm"}</title>
       </Helmet>
-      <div
-        aria-live="polite"
-        aria-atomic="true"
-        className="position-fixed top-0 end-0"
-        css={{ minWidth: 400, zIndex: 100 }}
-      >
-        <ToastContainer position="top-end" className="p-3">
-          {ctx.toasts.map((toast) => (
-            <Toast
-              key={toast.id}
-              show={!toast.hiding}
-              autohide={toast.delay !== undefined}
-              delay={toast.delay}
-              onClose={() => ctx.removeToast(toast.id)}
-            >
-              <Toast.Header>
-                <strong className="me-auto">{toast.title}</strong>
-                <small className="text-muted">just now</small>
-              </Toast.Header>
-              <Toast.Body>{toast.body}</Toast.Body>
-            </Toast>
-          ))}
-        </ToastContainer>
-      </div>
-      <Navbar
-        bg={ctx.settings.darkMode ? "dark" : "light"}
-        expand="lg"
-        css={{ "html.iframe &": { display: "none" } }}
-      >
-        <Container css={{ paddingLeft: 12, paddingRight: 12 }}>
-          <Link className="navbar-brand" to="/">
-            <span className="d-none d-sm-inline">Buddy's Almanac</span>
-            <FaHome className="d-sm-none" css={{ marginTop: -3 }} />
-          </Link>
-          <form
-            className="d-flex"
-            css={{ flexGrow: 1, maxWidth: 600 }}
-            onSubmit={(evt) => {
-              evt.preventDefault()
-              if (onSearchSubmit) onSearchSubmit()
-            }}
-          >
-            <input
-              id="nav-search"
-              className="form-control me-2"
-              type="search"
-              placeholder="Search"
-              aria-label="Search"
-              defaultValue={ctx.query || query || undefined}
-              autoFocus={searchAutoFocus}
-              onChange={(evt) => onSearchTypescriptSigh(evt.target.value)}
-            />
-          </form>
-          <Link
-            className="btn btn-primary"
-            to="/settings/"
-            onClick={
-              settingsBack
-                ? (evt) => {
-                    evt.preventDefault()
-                    void navigate(-1)
-                  }
-                : undefined
-            }
-          >
-            <span className="d-none d-sm-inline">Settings</span>
-            <BsFillGearFill className="d-sm-none" css={{ marginTop: -3 }} />
-          </Link>
-        </Container>
-      </Navbar>
       <main>
         <Container css={{ paddingTop: 10, paddingLeft: 12, paddingRight: 12 }}>
           {headerRight && <div className="d-none d-md-block float-end">{headerRight}</div>}

--- a/src/components/persistent-nav.tsx
+++ b/src/components/persistent-nav.tsx
@@ -145,6 +145,10 @@ export const PersistentNav = ({ children }: PersistentNavProps) => {
             css={{ flexGrow: 1, maxWidth: 600 }}
             onSubmit={(evt) => {
               evt.preventDefault()
+              // Navigate to first result on Enter key press
+              if (ctx.firstResultHref) {
+                void navigate(ctx.firstResultHref)
+              }
             }}
           >
             <input

--- a/src/components/persistent-nav.tsx
+++ b/src/components/persistent-nav.tsx
@@ -1,5 +1,7 @@
 import "bootstrap/dist/css/bootstrap.css"
 import "bootstrap-dark-5/dist/css/bootstrap-nightshade.css"
+import "react-bootstrap-typeahead/css/Typeahead.css"
+import "react-bootstrap-typeahead/css/Typeahead.bs5.css"
 
 import { navigate } from "gatsby"
 import React, { useContext, useEffect, useRef, useState } from "react"
@@ -72,6 +74,13 @@ export const PersistentNav = ({ children }: PersistentNavProps) => {
     if (isNavigatingRef.current && inputRef.current) {
       // Immediately refocus to prevent keyboard from closing
       inputRef.current.focus()
+    }
+  }
+
+  const handleSettingsClick = (evt: React.MouseEvent<HTMLAnchorElement>) => {
+    if (typeof window !== 'undefined' && window.location.pathname === '/settings/') {
+      evt.preventDefault()
+      void navigate(-1)
     }
   }
 
@@ -153,7 +162,7 @@ export const PersistentNav = ({ children }: PersistentNavProps) => {
               onBlur={handleBlur}
             />
           </form>
-          <Link className="btn btn-primary" to="/settings/">
+          <Link className="btn btn-primary" to="/settings/" onClick={handleSettingsClick}>
             <span className="d-none d-sm-inline">Settings</span>
             <BsFillGearFill className="d-sm-none" css={{ marginTop: -3 }} />
           </Link>

--- a/src/components/persistent-nav.tsx
+++ b/src/components/persistent-nav.tsx
@@ -1,0 +1,165 @@
+import "bootstrap/dist/css/bootstrap.css"
+import "bootstrap-dark-5/dist/css/bootstrap-nightshade.css"
+
+import { navigate } from "gatsby"
+import React, { useContext, useEffect, useRef, useState } from "react"
+import Container from "react-bootstrap/Container"
+import Navbar from "react-bootstrap/Navbar"
+import Toast from "react-bootstrap/Toast"
+import ToastContainer from "react-bootstrap/ToastContainer"
+import { Link } from "gatsby"
+
+import { BsFillGearFill } from "@react-icons/all-files/bs/BsFillGearFill"
+import { FaHome } from "@react-icons/all-files/fa/FaHome"
+
+import { useDebounce } from "../hooks/debounce"
+import { GlobalContext } from "../utils/context"
+
+interface PersistentNavProps {
+  children: React.ReactNode
+}
+
+export const PersistentNav = ({ children }: PersistentNavProps) => {
+  const ctx = useContext(GlobalContext)
+  const [searchFired, setSearchFired] = useState(false)
+  const [inputValue, setInputValue] = useState("")
+  const isNavigatingRef = useRef(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Sync input value with URL query parameter when on search page
+  // Clear input when navigating away from search page
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const isOnSearchPage = window.location.pathname === '/search/'
+
+      if (isOnSearchPage) {
+        // On search page: sync input with URL query parameter
+        const params = new URLSearchParams(window.location.search)
+        const q = params.get('q')
+        if (q !== null && q !== inputValue) {
+          setInputValue(q)
+        }
+        // Reset searchFired when navigating to search page
+        setSearchFired(false)
+      } else {
+        // Not on search page: clear the input
+        if (inputValue !== '') {
+          setInputValue('')
+        }
+      }
+    }
+  }, [typeof window !== 'undefined' ? window.location.href : ''])
+
+  const navigateToSearch = useDebounce((query: string, setSearchFired: (arg0: boolean) => void) => {
+    isNavigatingRef.current = true
+    void navigate(`/search/?q=${encodeURIComponent(query)}`)
+    setSearchFired(true)
+  }, 250)
+
+  // Reset navigation flag when URL changes (navigation complete)
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      // Small delay to allow search page to refocus
+      const timer = setTimeout(() => {
+        isNavigatingRef.current = false
+      }, 100)
+      return () => clearTimeout(timer)
+    }
+  }, [typeof window !== 'undefined' ? window.location.href : ''])
+
+  // Prevent blur during navigation to keep mobile keyboard open
+  const handleBlur = () => {
+    if (isNavigatingRef.current && inputRef.current) {
+      // Immediately refocus to prevent keyboard from closing
+      inputRef.current.focus()
+    }
+  }
+
+  const onSearch = (query: string): void => {
+    // Check if we're already on the search page
+    const isOnSearchPage = typeof window !== 'undefined' && window.location.pathname === '/search/'
+
+    if (isOnSearchPage) {
+      // On search page: update context for real-time search
+      ctx.setQuery(query)
+      // Update the URL without navigating
+      if (typeof window !== 'undefined') {
+        window.history.replaceState(null, '', `?q=${encodeURIComponent(query)}`)
+      }
+    } else {
+      // Not on search page: navigate to search page with query in URL
+      if (!searchFired && query.length > 1) {
+        ctx.setQuery(query)
+        navigateToSearch(query, setSearchFired)
+      }
+    }
+  }
+
+  return (
+    <>
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="position-fixed top-0 end-0"
+        css={{ minWidth: 400, zIndex: 100 }}
+      >
+        <ToastContainer position="top-end" className="p-3">
+          {ctx.toasts.map((toast) => (
+            <Toast
+              key={toast.id}
+              show={!toast.hiding}
+              autohide={toast.delay !== undefined}
+              delay={toast.delay}
+              onClose={() => ctx.removeToast(toast.id)}
+            >
+              <Toast.Header>
+                <strong className="me-auto">{toast.title}</strong>
+                <small className="text-muted">just now</small>
+              </Toast.Header>
+              <Toast.Body>{toast.body}</Toast.Body>
+            </Toast>
+          ))}
+        </ToastContainer>
+      </div>
+      <Navbar
+        bg={ctx.settings.darkMode ? "dark" : "light"}
+        expand="lg"
+        css={{ "html.iframe &": { display: "none" } }}
+      >
+        <Container css={{ paddingLeft: 12, paddingRight: 12 }}>
+          <Link className="navbar-brand" to="/">
+            <span className="d-none d-sm-inline">Buddy's Almanac</span>
+            <FaHome className="d-sm-none" css={{ marginTop: -3 }} />
+          </Link>
+          <form
+            className="d-flex"
+            css={{ flexGrow: 1, maxWidth: 600 }}
+            onSubmit={(evt) => {
+              evt.preventDefault()
+            }}
+          >
+            <input
+              ref={inputRef}
+              id="nav-search"
+              className="form-control me-2"
+              type="search"
+              placeholder="Search"
+              aria-label="Search"
+              value={inputValue}
+              onChange={(evt) => {
+                setInputValue(evt.target.value)
+                onSearch(evt.target.value)
+              }}
+              onBlur={handleBlur}
+            />
+          </form>
+          <Link className="btn btn-primary" to="/settings/">
+            <span className="d-none d-sm-inline">Settings</span>
+            <BsFillGearFill className="d-sm-none" css={{ marginTop: -3 }} />
+          </Link>
+        </Container>
+      </Navbar>
+      {children}
+    </>
+  )
+}

--- a/src/hooks/debounce.tsx
+++ b/src/hooks/debounce.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export const useDebounce = <T extends (...args: any[]) => void,>(func: T, wait: number) => {
   const [timeout, setTimeout_] = useState<number | undefined>(undefined)
@@ -11,6 +11,22 @@ export const useDebounce = <T extends (...args: any[]) => void,>(func: T, wait: 
     clearTimeout(timeout)
     setTimeout_(window.setTimeout(later, wait))
   }
+}
+
+export const useDebouncedValue = <T,>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
 }
 
 export const useDebounceAfter = <T extends (...args: any[]) => void,>(func: T, wait: number) => {

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,21 +1,13 @@
 import { useContext, useEffect, useState } from "react"
-import { navigate } from "gatsby"
 
 import { keyframes } from "@emotion/react"
 import { CgSpinner } from "@react-icons/all-files/cg/CgSpinner"
 
 import Layout from "../components/layout"
 import List from "../components/list"
-import { useDebounce } from "../hooks/debounce"
 import { GlobalContext } from "../utils/context"
 
-import type { Searchable } from "../utils/context"
-
-declare global {
-  interface Window {
-    _farmSearchables?: Searchable[] | undefined
-  }
-}
+import { useDebouncedValue } from "../hooks/debounce"
 
 interface ScoredResult {
   name: string
@@ -62,50 +54,21 @@ const spin = keyframes`
   to { transform: rotate(360deg); }
 `
 
-interface SearchProps {
-  location?: {
-    state?: {
-      typing: boolean
-      query: string
-    }
-  }
-}
-
-export default ({ location }: SearchProps) => {
+export default () => {
   const ctx = useContext(GlobalContext)
-  // const [searchables, setSearchables] = useState<Searchable[] | null>(null)
-  // const [inputFocus, setInputFocus] = useState(false)
-  const [query, setQuery] = useState<string | undefined>(ctx.query || undefined)
   const [results, setResults] = useState<ScoredResult[] | null>(null)
   const inBrowser = typeof document !== "undefined"
 
-  // Get the search query from the URL.
-  // Based on https://github.com/akash-joshi/gatsby-query-params/blob/f997c33cdee82d053c6591ff3b71b7d54cce07d3/src/index.js
+  // Debounce the query to reduce number of searches
+  const deferredQuery = useDebouncedValue(ctx.query, 150)
+
+  // Initialize query from URL on mount
   useEffect(() => {
     if (inBrowser) {
-      console.log("search effect, typing state is", location?.state?.typing)
-      // THIS IS A VERY SILLY SOLUTION BUT ITS BETTER THAN NOTHING.
-      if (location?.state?.typing) {
-        setTimeout(() => {
-          console.log("search setting focus")
-          document.getElementById("nav-search")?.focus()
-        }, 1)
-      }
-
-      if (location?.state?.typing && ctx.query !== null) {
-        // Automatic navigation, assume we're taking over a query from another page.
-        // In case the navigate got a little confused, update things.
-        history.replaceState(null, "", `?q=${encodeURIComponent(ctx.query)}`)
-        // Transfer the global query into local state and clear it for the next page.
-        ctx.setQuery(null)
-        setQuery(ctx.query || undefined)
-      } else {
-        // Natural navigation, load the query from the URL.
-        const params = new URLSearchParams(document.location.search)
-        const q = params.get("q")
-        if (q !== null) {
-          setQuery(q)
-        }
+      const params = new URLSearchParams(document.location.search)
+      const q = params.get("q")
+      if (q !== null) {
+        ctx.setQuery(q)
       }
       if (ctx.searchables === null) {
         // Start loading the searchables.
@@ -118,33 +81,17 @@ export default ({ location }: SearchProps) => {
     }
   }, [])
 
-  const slowSetQuery = useDebounce(setQuery, 150)
-
-  const onSearch = (query: string) => {
-    slowSetQuery(query)
-    history.replaceState(null, "", `?q=${encodeURIComponent(query)}`)
-  }
-
-  const onSearchSubmit = () => {
-    if (results && results.length >= 1) {
-      void navigate(results[0].href)
-    }
-  }
-
-  // const onSearchFocus = (focus: boolean) => {
-  //   setInputFocus(focus)
-  // }
-
+  // Run search when debounced deferred query or searchables change
   useEffect(() => {
     if (ctx.searchables !== null) {
       // Filter and sort the results.
-      if (!query) {
+      if (!deferredQuery) {
         setResults([])
         return
       }
 
       // Setup for scoring.
-      const queryLower = query.toLowerCase().trim()
+      const queryLower = deferredQuery.toLowerCase().trim()
       const queryClean = queryLower.replace(/[()[\]]/g, "")
       if (queryClean.length < 2) {
         setResults([])
@@ -163,18 +110,10 @@ export default ({ location }: SearchProps) => {
       scored.sort((a, b) => a.score - b.score)
       setResults(scored)
     }
-  }, [query, ctx.searchables])
-
-  console.log("search render, typing state is", location?.state?.typing)
+  }, [deferredQuery, ctx.searchables])
 
   return (
-    <Layout
-      pageTitle="Buddy's Almanac"
-      query={query}
-      searchAutoFocus={!!location?.state?.typing}
-      onSearch={onSearch}
-      onSearchSubmit={onSearchSubmit}
-    >
+    <Layout pageTitle="Buddy's Almanac">
       <div>Search results</div>
       {results !== null ? (
         <List
@@ -203,4 +142,4 @@ export default ({ location }: SearchProps) => {
       )}
     </Layout>
   )
-}
+};

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -60,7 +60,7 @@ export default () => {
   const inBrowser = typeof document !== "undefined"
 
   // Debounce the query to reduce number of searches
-  const deferredQuery = useDebouncedValue(ctx.query, 150)
+  const query = useDebouncedValue(ctx.query, 150)
 
   // Initialize query from URL on mount
   useEffect(() => {
@@ -85,16 +85,18 @@ export default () => {
   useEffect(() => {
     if (ctx.searchables !== null) {
       // Filter and sort the results.
-      if (!deferredQuery) {
+      if (!query) {
         setResults([])
+        ctx.setFirstResultHref(null)
         return
       }
 
       // Setup for scoring.
-      const queryLower = deferredQuery.toLowerCase().trim()
+      const queryLower = query.toLowerCase().trim()
       const queryClean = queryLower.replace(/[()[\]]/g, "")
       if (queryClean.length < 2) {
         setResults([])
+        ctx.setFirstResultHref(null)
         return
       }
       const queryRegexp = prepScoring(queryClean)
@@ -109,8 +111,10 @@ export default () => {
       }
       scored.sort((a, b) => a.score - b.score)
       setResults(scored)
+      // Update first result href for Enter key navigation
+      ctx.setFirstResultHref(scored.length > 0 ? scored[0].href : null)
     }
-  }, [deferredQuery, ctx.searchables])
+  }, [query, ctx.searchables])
 
   return (
     <Layout pageTitle="Buddy's Almanac">

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -16,6 +16,8 @@ interface ContextProps {
   setSearchables: React.Dispatch<React.SetStateAction<Searchable[] | null>>
   query: string | null
   setQuery: React.Dispatch<React.SetStateAction<string | null>>
+  firstResultHref: string | null
+  setFirstResultHref: React.Dispatch<React.SetStateAction<string | null>>
   settings: Settings
   setSettings: SetSettings
   setSetting: SetSetting
@@ -29,6 +31,8 @@ export const GlobalContext = React.createContext<ContextProps>({
   setSearchables: () => null,
   query: null,
   setQuery: () => null,
+  firstResultHref: null,
+  setFirstResultHref: () => null,
   settings: {},
   setSettings: () => null,
   setSetting: () => null,
@@ -44,6 +48,7 @@ interface ProviderProps {
 const Provider = ({ children }: ProviderProps) => {
   const [searchables, setSearchables] = useState<Searchable[] | null>(null)
   const [query, setQuery] = useState<string | null>(null)
+  const [firstResultHref, setFirstResultHref] = useState<string | null>(null)
   const [settings, setSettings, setSetting] = useSettings()
   const [toasts, addToast, removeToast] = useToasts()
 
@@ -58,7 +63,7 @@ const Provider = ({ children }: ProviderProps) => {
   }, [settings.darkMode])
 
   return (
-    <GlobalContext.Provider value={{ searchables, setSearchables, query, setQuery, settings, setSettings, setSetting, toasts, addToast, removeToast }}>
+    <GlobalContext.Provider value={{ searchables, setSearchables, query, setQuery, firstResultHref, setFirstResultHref, settings, setSettings, setSetting, toasts, addToast, removeToast }}>
       {children}
     </GlobalContext.Provider>
   )


### PR DESCRIPTION
# Fix mobile keyboard retraction on search navigation

## Summary

- Fixes mobile keyboard retraction when navigating from item pages to search page while typing
- Simplifies codebase by extracting persistent UI elements into dedicated component

## Problem

When typing in the nav search bar on mobile and navigating from an item page to the search page, the input would flash and unmount/remount, causing the mobile keyboard to retract. This disrupts the search flow on mobile devices.

**Root cause:** Each Gatsby page had its own Layout instance containing the navbar. During page navigation, the Layout (and search input) would unmount and remount, destroying the focused element.

## Solution

### Persistent Navigation Architecture
- Created new `PersistentNav` component using Gatsby's `wrapPageElement` API
- Navbar and search input now live above the page level and persist across all navigations
- Added blur prevention mechanism using refs to keep input focused during navigation

### Code Simplification
- Extracted navbar, toasts, and search logic from `layout.tsx` into `PersistentNav`
- Simplified `search.tsx` to use global context as single source of truth
- Removed unnecessary `typing` state logic - URL query parameter is now the single source of truth

## Testing

- [x] Mobile keyboard stays open when navigating from item page → search page
- [x] No input flashing or unmounting during navigation
- [x] Debounce still working for search
- [x] URL properly syncs with search input on all pages
- [x] Search input clears when navigating away from search page
- [x] Settings button navigates back when already on settings page (preserved original behavior)
- [x] Enter key navigates to first search result (preserved original behavior)

Tested locally on desktop browser, as well as iOS (using `gatsby develop -H 0.0.0.0`) and connecting through `http:${desktopIP}:8000` over wifi on Chrome and Safari 

## Files Changed

- **NEW**: `src/components/persistent-nav.tsx` - Persistent navigation wrapper component with blur prevention
- **Modified**: `gatsby-browser.js` - Added wrapPageElement for client-side rendering
- **Modified**: `gatsby-ssr.js` - Added wrapPageElement for server-side rendering
- **Modified**: `src/components/layout.tsx` - Removed navbar, toasts, and search logic (~114 lines removed)
- **Modified**: `src/pages/search.tsx` - Simplified state management, added debouncing, tracks first result for Enter key navigation
- **Modified**: `src/hooks/debounce.tsx` - Added useDebouncedValue hook
- **Modified**: `src/utils/context.tsx` - Added firstResultHref state for Enter key navigation
## Statistics

- 7 files changed
- ~220 insertions, ~190 deletions

Please let me know if you would like to see any changes to this PR. Thanks!